### PR TITLE
Feat/negative sign placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## [2.3.0] - 2025-05-25
 
 ### Added
-
--   Added `negativeSignPlacement` option to `CurrencyFormat` to control the position of the negative sign. This allows formatting like `-€123.45` or `-$123.45` when the symbol is on the left and `negativeSignPlacement` is set to `NegativeSignPlacement.beforeSymbol`. Defaults to previous behavior (e.g., `€-123.45` or `$-123.45`) if not specified or if `negativeSignPlacement` is `NegativeSignPlacement.afterSymbol`.
+- Added `negativeSignPlacement` option to `CurrencyFormat` to control the position of the negative sign. This allows formatting like `-€123.45` or `-$123.45` when the symbol is on the left and `negativeSignPlacement` is set to `NegativeSignPlacement.beforeSymbol`. Defaults to previous behavior (e.g., `€-123.45` or `$-123.45`) if not specified or if `negativeSignPlacement` is `NegativeSignPlacement.afterSymbol`.
 
 ## [2.2.3] - 2025-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [2.3.0] - 2025-05-25
 
 ### Added
-- Added `negativeSignPlacement` option to `CurrencyFormat` to control the position of the negative sign. This allows formatting like `-€123.45` or `-$123.45` when the symbol is on the left and `negativeSignPlacement` is set to `NegativeSignPlacement.beforeSymbol`. Defaults to previous behavior (e.g., `€-123.45` or `$-123.45`) if not specified or if `negativeSignPlacement` is `NegativeSignPlacement.afterSymbol`.
+
+-   Added `negativeSignPlacement` option to `CurrencyFormat` to control the position of the negative sign. This allows formatting like `-€123.45` or `-$123.45` when the symbol is on the left and `negativeSignPlacement` is set to `NegativeSignPlacement.beforeSymbol`. Defaults to previous behavior (e.g., `€-123.45` or `$-123.45`) if not specified or if `negativeSignPlacement` is `NegativeSignPlacement.afterSymbol`.
 
 ## [2.2.3] - 2025-04-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.3.0] - 2025-05-25
+
+### Added
+- Added `negativeSignPlacement` option to `CurrencyFormat` to control the position of the negative sign. This allows formatting like `-€123.45` or `-$123.45` when the symbol is on the left and `negativeSignPlacement` is set to `NegativeSignPlacement.beforeSymbol`. Defaults to previous behavior (e.g., `€-123.45` or `$-123.45`) if not specified or if `negativeSignPlacement` is `NegativeSignPlacement.afterSymbol`.
+
 ## [2.2.3] - 2025-04-08
 
 -   Replaced `dart:html` usage with `package:web`.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ CurrencyFormat euroSettings = CurrencyFormat(
 );
 ```
 
-`symbolSide` can be set to `SymbolSide.left`, `SymbolSide.right`, or `SymbolSide.none`.
-`thousandSeparator` and `decimalSeparator` default to `'.'`, `','` or `','`,`'.'` automatically
-depending on `symbolSide`.
+-   `symbolSide` can be set to `SymbolSide.left`, `SymbolSide.right`, or `SymbolSide.none`.
+-   `thousandSeparator` and `decimalSeparator` default to `'.'`, `','` or `','`,`'.'` automatically depending on `symbolSide`.
+-   `negativeSignPlacement` can be set to `NegativeSignPlacement.beforeSymbol` or `NegativeSignPlacement.afterSymbol`, and defaults to `NegativeSignPlacement.afterSymbol`.
 
 To format a `num`, `CurrencyFormatter.format()` is used:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ CurrencyFormat euroSettings = CurrencyFormat(
 );
 ```
 
-`symbolSide` can be set to `SymbolSide.left`, `SymbolSide.right`, or `SymbolSide.none`.
-`thousandSeparator` and `decimalSeparator` default to `'.'`, `','` or `','`,`'.'` automatically
-depending on `symbolSide`.
+- `symbolSide` can be set to `SymbolSide.left`, `SymbolSide.right`, or `SymbolSide.none`.
+- `thousandSeparator` and `decimalSeparator` default to `'.'`, `','` or `','`,`'.'` automatically depending on `symbolSide`.
+- `negativeSignPlacement`: An option on `CurrencyFormat` (e.g. set via `copyWith`) that controls the placement of the negative sign when formatting negative amounts. Use `NegativeSignPlacement.beforeSymbol` to place the sign before the currency symbol (e.g., `-\$100`) when the symbol is on the left. Defaults to `NegativeSignPlacement.afterSymbol` (e.g., `\$-100`).
 
 To format a `num`, `CurrencyFormatter.format()` is used:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ CurrencyFormat euroSettings = CurrencyFormat(
 );
 ```
 
-- `symbolSide` can be set to `SymbolSide.left`, `SymbolSide.right`, or `SymbolSide.none`.
-- `thousandSeparator` and `decimalSeparator` default to `'.'`, `','` or `','`,`'.'` automatically depending on `symbolSide`.
-- `negativeSignPlacement`: An option on `CurrencyFormat` (e.g. set via `copyWith`) that controls the placement of the negative sign when formatting negative amounts. Use `NegativeSignPlacement.beforeSymbol` to place the sign before the currency symbol (e.g., `-\$100`) when the symbol is on the left. Defaults to `NegativeSignPlacement.afterSymbol` (e.g., `\$-100`).
+`symbolSide` can be set to `SymbolSide.left`, `SymbolSide.right`, or `SymbolSide.none`.
+`thousandSeparator` and `decimalSeparator` default to `'.'`, `','` or `','`,`'.'` automatically
+depending on `symbolSide`.
 
 To format a `num`, `CurrencyFormatter.format()` is used:
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -70,9 +70,70 @@ void main() {
     khr,
   ];
 
-  CurrencyFormat.fromSymbol('៛'); // null
-  CurrencyFormat.fromSymbol('៛', myCurrencies); // khr
+  print('Formatted: $formatted');
+  print('Compact: $compact');
+  print('Three Decimal: $threeDecimal');
+  print('Parsed Formatted: $parseFormatted');
+  print('Parsed Compact: $parseCompact');
+  print('Parsed Three Decimal: $parseThreeDecimal');
+  print('In USD: $inUSD');
+  print('In RUB: $inRUB');
+  print('JPY Symbol: $jpySymbol');
+  print('USD Symbol: $usdSymbol');
+  print('In System Currency: $inSystemCurrency');
+  print('From Symbol (£): $fromSymbol');
+  print('No Space USD: $noSpace');
+  print('No Decimal (int amount): $noDecimal');
+  print('Enforce Decimal: $enforceDecimal');
+  print('No Symbol: $noSymbol');
+
+  CurrencyFormat? khrFromSymbol = CurrencyFormat.fromSymbol('៛');
+  print('KHR from symbol (default list): $khrFromSymbol');
+  CurrencyFormat? khrFromSymbolMyList =
+      CurrencyFormat.fromSymbol('៛', myCurrencies);
+  print('KHR from symbol (myCurrencies list): $khrFromSymbolMyList');
 
   CurrencyFormat? localCurrency() =>
       CurrencyFormat.fromSymbol(CurrencyFormat.localSymbol, myCurrencies);
+  print('Local currency from myCurrencies list: ${localCurrency()}');
+
+  // --- Custom Negative Sign Placement ---
+  print('\n// --- Custom Negative Sign Placement ---');
+  final tryNegativeBefore = CurrencyFormat.tryx.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+  );
+  double negativeAmountTRY = -76231.24;
+  print(
+      'Turkish Lira (negative before symbol): ${CurrencyFormatter.format(negativeAmountTRY, tryNegativeBefore)}'); // Expected: -₺76,231.24
+
+  final usdNegativeBefore = CurrencyFormat.usd.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+  );
+  double negativeAmountUSD = -1234.56;
+  print(
+      'USD (negative before symbol): ${CurrencyFormatter.format(negativeAmountUSD, usdNegativeBefore)}'); // Expected: -$1,234.56
+
+  final usdNegativeAfter = CurrencyFormat.usd.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.afterSymbol,
+  );
+  print(
+      'USD (negative after symbol): ${CurrencyFormatter.format(negativeAmountUSD, usdNegativeAfter)}'); // Expected: $-1,234.56
+  
+  // Example with default negativeSignPlacement (should be afterSymbol for USD)
+  print(
+      'USD (negative default placement): ${CurrencyFormatter.format(negativeAmountUSD, CurrencyFormat.usd)}'); // Expected: $-1,234.56
+
+  // Example for EUR (symbol on the right)
+  final eurNegativeBefore = CurrencyFormat.eur.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+  );
+  print(
+    'EUR (negative before symbol, symbol right): ${CurrencyFormatter.format(negativeAmountUSD, eurNegativeBefore)}'); // Expected: -1.234,56 €
+  
+  final eurNegativeAfter = CurrencyFormat.eur.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.afterSymbol,
+  );
+   print(
+    'EUR (negative after symbol, symbol right): ${CurrencyFormatter.format(negativeAmountUSD, eurNegativeAfter)}'); // Expected: -1.234,56 €
+
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -45,13 +45,6 @@ void main() {
   String noSpace =
       CurrencyFormatter.format(amount, noSpaceSettings); // $1,910.93
 
-  CurrencyFormat negativeBeforeSymbolSettings = CurrencyFormat.tryx.copyWith(
-    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
-    symbolSeparator: '',
-  );
-  String negativeBeforeSymbol = CurrencyFormatter.format(
-      amount, negativeBeforeSymbolSettings); // -₺1,910.93
-
   int intAmount = 3;
   String noDecimal = CurrencyFormatter.format(intAmount, euroSettings); // 3 €
 
@@ -66,9 +59,6 @@ void main() {
   String noSymbol =
       CurrencyFormatter.format(amount, noSymbolFormat); // 1.910,93
 
-  // --------------------------------------------------------------------------
-  // Custom currency list
-
   const CurrencyFormat khr = CurrencyFormat(
     code: 'khr',
     symbol: '៛',
@@ -79,14 +69,6 @@ void main() {
     ...CurrencyFormatter.majorsList,
     khr,
   ];
-
-  CurrencyFormat.fromSymbol('៛'); // null
-  CurrencyFormat.fromSymbol('៛', myCurrencies); // khr
-
-  CurrencyFormat? localCurrency() =>
-      CurrencyFormat.fromSymbol(CurrencyFormat.localSymbol, myCurrencies);
-
-  // --------------------------------------------------------------------------
 
   print('Formatted: $formatted');
   print('Compact: $compact');
@@ -101,9 +83,57 @@ void main() {
   print('In System Currency: $inSystemCurrency');
   print('From Symbol (£): $fromSymbol');
   print('No Space USD: $noSpace');
-  print('Negative Before Symbol: $negativeBeforeSymbol');
   print('No Decimal (int amount): $noDecimal');
   print('Enforce Decimal: $enforceDecimal');
   print('No Symbol: $noSymbol');
-  print('Local Currency: ${localCurrency()}');
+
+  CurrencyFormat? khrFromSymbol = CurrencyFormat.fromSymbol('៛');
+  print('KHR from symbol (default list): $khrFromSymbol');
+  CurrencyFormat? khrFromSymbolMyList =
+      CurrencyFormat.fromSymbol('៛', myCurrencies);
+  print('KHR from symbol (myCurrencies list): $khrFromSymbolMyList');
+
+  CurrencyFormat? localCurrency() =>
+      CurrencyFormat.fromSymbol(CurrencyFormat.localSymbol, myCurrencies);
+  print('Local currency from myCurrencies list: ${localCurrency()}');
+
+  // --- Custom Negative Sign Placement ---
+  print('\n// --- Custom Negative Sign Placement ---');
+  final tryNegativeBefore = CurrencyFormat.tryx.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+  );
+  double negativeAmountTRY = -76231.24;
+  print(
+      'Turkish Lira (negative before symbol): ${CurrencyFormatter.format(negativeAmountTRY, tryNegativeBefore)}'); // Expected: -₺76,231.24
+
+  final usdNegativeBefore = CurrencyFormat.usd.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+  );
+  double negativeAmountUSD = -1234.56;
+  print(
+      'USD (negative before symbol): ${CurrencyFormatter.format(negativeAmountUSD, usdNegativeBefore)}'); // Expected: -$1,234.56
+
+  final usdNegativeAfter = CurrencyFormat.usd.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.afterSymbol,
+  );
+  print(
+      'USD (negative after symbol): ${CurrencyFormatter.format(negativeAmountUSD, usdNegativeAfter)}'); // Expected: $-1,234.56
+  
+  // Example with default negativeSignPlacement (should be afterSymbol for USD)
+  print(
+      'USD (negative default placement): ${CurrencyFormatter.format(negativeAmountUSD, CurrencyFormat.usd)}'); // Expected: $-1,234.56
+
+  // Example for EUR (symbol on the right)
+  final eurNegativeBefore = CurrencyFormat.eur.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+  );
+  print(
+    'EUR (negative before symbol, symbol right): ${CurrencyFormatter.format(negativeAmountUSD, eurNegativeBefore)}'); // Expected: -1.234,56 €
+  
+  final eurNegativeAfter = CurrencyFormat.eur.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.afterSymbol,
+  );
+   print(
+    'EUR (negative after symbol, symbol right): ${CurrencyFormatter.format(negativeAmountUSD, eurNegativeAfter)}'); // Expected: -1.234,56 €
+
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -45,6 +45,13 @@ void main() {
   String noSpace =
       CurrencyFormatter.format(amount, noSpaceSettings); // $1,910.93
 
+  CurrencyFormat negativeBeforeSymbolSettings = CurrencyFormat.tryx.copyWith(
+    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+    symbolSeparator: '',
+  );
+  String negativeBeforeSymbol = CurrencyFormatter.format(
+      amount, negativeBeforeSymbolSettings); // -₺1,910.93
+
   int intAmount = 3;
   String noDecimal = CurrencyFormatter.format(intAmount, euroSettings); // 3 €
 
@@ -59,6 +66,9 @@ void main() {
   String noSymbol =
       CurrencyFormatter.format(amount, noSymbolFormat); // 1.910,93
 
+  // --------------------------------------------------------------------------
+  // Custom currency list
+
   const CurrencyFormat khr = CurrencyFormat(
     code: 'khr',
     symbol: '៛',
@@ -69,6 +79,14 @@ void main() {
     ...CurrencyFormatter.majorsList,
     khr,
   ];
+
+  CurrencyFormat.fromSymbol('៛'); // null
+  CurrencyFormat.fromSymbol('៛', myCurrencies); // khr
+
+  CurrencyFormat? localCurrency() =>
+      CurrencyFormat.fromSymbol(CurrencyFormat.localSymbol, myCurrencies);
+
+  // --------------------------------------------------------------------------
 
   print('Formatted: $formatted');
   print('Compact: $compact');
@@ -83,57 +101,9 @@ void main() {
   print('In System Currency: $inSystemCurrency');
   print('From Symbol (£): $fromSymbol');
   print('No Space USD: $noSpace');
+  print('Negative Before Symbol: $negativeBeforeSymbol');
   print('No Decimal (int amount): $noDecimal');
   print('Enforce Decimal: $enforceDecimal');
   print('No Symbol: $noSymbol');
-
-  CurrencyFormat? khrFromSymbol = CurrencyFormat.fromSymbol('៛');
-  print('KHR from symbol (default list): $khrFromSymbol');
-  CurrencyFormat? khrFromSymbolMyList =
-      CurrencyFormat.fromSymbol('៛', myCurrencies);
-  print('KHR from symbol (myCurrencies list): $khrFromSymbolMyList');
-
-  CurrencyFormat? localCurrency() =>
-      CurrencyFormat.fromSymbol(CurrencyFormat.localSymbol, myCurrencies);
-  print('Local currency from myCurrencies list: ${localCurrency()}');
-
-  // --- Custom Negative Sign Placement ---
-  print('\n// --- Custom Negative Sign Placement ---');
-  final tryNegativeBefore = CurrencyFormat.tryx.copyWith(
-    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
-  );
-  double negativeAmountTRY = -76231.24;
-  print(
-      'Turkish Lira (negative before symbol): ${CurrencyFormatter.format(negativeAmountTRY, tryNegativeBefore)}'); // Expected: -₺76,231.24
-
-  final usdNegativeBefore = CurrencyFormat.usd.copyWith(
-    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
-  );
-  double negativeAmountUSD = -1234.56;
-  print(
-      'USD (negative before symbol): ${CurrencyFormatter.format(negativeAmountUSD, usdNegativeBefore)}'); // Expected: -$1,234.56
-
-  final usdNegativeAfter = CurrencyFormat.usd.copyWith(
-    negativeSignPlacement: NegativeSignPlacement.afterSymbol,
-  );
-  print(
-      'USD (negative after symbol): ${CurrencyFormatter.format(negativeAmountUSD, usdNegativeAfter)}'); // Expected: $-1,234.56
-  
-  // Example with default negativeSignPlacement (should be afterSymbol for USD)
-  print(
-      'USD (negative default placement): ${CurrencyFormatter.format(negativeAmountUSD, CurrencyFormat.usd)}'); // Expected: $-1,234.56
-
-  // Example for EUR (symbol on the right)
-  final eurNegativeBefore = CurrencyFormat.eur.copyWith(
-    negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
-  );
-  print(
-    'EUR (negative before symbol, symbol right): ${CurrencyFormatter.format(negativeAmountUSD, eurNegativeBefore)}'); // Expected: -1.234,56 €
-  
-  final eurNegativeAfter = CurrencyFormat.eur.copyWith(
-    negativeSignPlacement: NegativeSignPlacement.afterSymbol,
-  );
-   print(
-    'EUR (negative after symbol, symbol right): ${CurrencyFormatter.format(negativeAmountUSD, eurNegativeAfter)}'); // Expected: -1.234,56 €
-
+  print('Local Currency: ${localCurrency()}');
 }

--- a/lib/currency_formatter.dart
+++ b/lib/currency_formatter.dart
@@ -58,26 +58,31 @@ abstract class CurrencyFormatter {
     // Rounding for non-enforced decimals (only if not compact)
     // This must use '.' for parsing, so it's done before replacing the decimal separator.
     if (!enforceDecimals && !compact) {
-      double tempNum = double.parse(formattedNumberString); // Assumes '.' as decimal separator
+      double tempNum = double.parse(
+          formattedNumberString); // Assumes '.' as decimal separator
       if (tempNum == tempNum.round()) {
         formattedNumberString = tempNum.round().toString();
       }
     }
-    
+
     // Replace '.' with the settings-defined decimal separator
-    formattedNumberString = formattedNumberString.replaceAll('.', settings.decimalSeparator);
+    formattedNumberString =
+        formattedNumberString.replaceAll('.', settings.decimalSeparator);
 
     // Apply thousand separator if needed
     // This operates on the number string which is now purely numerical (absolute)
     // and has the correct decimal separator.
     if (showThousandSeparator) {
-      List<String> parts = formattedNumberString.split(settings.decimalSeparator);
+      List<String> parts =
+          formattedNumberString.split(settings.decimalSeparator);
       String integerPart = parts[0];
-      String decimalPart = parts.length > 1 ? settings.decimalSeparator + parts[1] : '';
-      
+      String decimalPart =
+          parts.length > 1 ? settings.decimalSeparator + parts[1] : '';
+
       String newIntegerPart = '';
       for (int i = 0; i < integerPart.length; i++) {
-        newIntegerPart = integerPart[integerPart.length - i - 1] + newIntegerPart;
+        newIntegerPart =
+            integerPart[integerPart.length - i - 1] + newIntegerPart;
         if ((i + 1) % 3 == 0 && i < integerPart.length - 1) {
           newIntegerPart = settings.thousandSeparator + newIntegerPart;
         }
@@ -89,10 +94,12 @@ abstract class CurrencyFormatter {
     String signComponent = '';
     if (isNegative) {
       if (settings.symbolSide == SymbolSide.left &&
-          settings.negativeSignPlacement == NegativeSignPlacement.beforeSymbol) {
+          settings.negativeSignPlacement ==
+              NegativeSignPlacement.beforeSymbol) {
         signComponent = '-'; // Sign will go before the symbol
       } else {
-        formattedNumberString = '-$formattedNumberString'; // Sign will go with the number
+        formattedNumberString =
+            '-$formattedNumberString'; // Sign will go with the number
       }
     }
 

--- a/lib/currency_formatter.dart
+++ b/lib/currency_formatter.dart
@@ -58,31 +58,26 @@ abstract class CurrencyFormatter {
     // Rounding for non-enforced decimals (only if not compact)
     // This must use '.' for parsing, so it's done before replacing the decimal separator.
     if (!enforceDecimals && !compact) {
-      double tempNum = double.parse(
-          formattedNumberString); // Assumes '.' as decimal separator
+      double tempNum = double.parse(formattedNumberString); // Assumes '.' as decimal separator
       if (tempNum == tempNum.round()) {
         formattedNumberString = tempNum.round().toString();
       }
     }
-
+    
     // Replace '.' with the settings-defined decimal separator
-    formattedNumberString =
-        formattedNumberString.replaceAll('.', settings.decimalSeparator);
+    formattedNumberString = formattedNumberString.replaceAll('.', settings.decimalSeparator);
 
     // Apply thousand separator if needed
     // This operates on the number string which is now purely numerical (absolute)
     // and has the correct decimal separator.
     if (showThousandSeparator) {
-      List<String> parts =
-          formattedNumberString.split(settings.decimalSeparator);
+      List<String> parts = formattedNumberString.split(settings.decimalSeparator);
       String integerPart = parts[0];
-      String decimalPart =
-          parts.length > 1 ? settings.decimalSeparator + parts[1] : '';
-
+      String decimalPart = parts.length > 1 ? settings.decimalSeparator + parts[1] : '';
+      
       String newIntegerPart = '';
       for (int i = 0; i < integerPart.length; i++) {
-        newIntegerPart =
-            integerPart[integerPart.length - i - 1] + newIntegerPart;
+        newIntegerPart = integerPart[integerPart.length - i - 1] + newIntegerPart;
         if ((i + 1) % 3 == 0 && i < integerPart.length - 1) {
           newIntegerPart = settings.thousandSeparator + newIntegerPart;
         }
@@ -94,12 +89,10 @@ abstract class CurrencyFormatter {
     String signComponent = '';
     if (isNegative) {
       if (settings.symbolSide == SymbolSide.left &&
-          settings.negativeSignPlacement ==
-              NegativeSignPlacement.beforeSymbol) {
+          settings.negativeSignPlacement == NegativeSignPlacement.beforeSymbol) {
         signComponent = '-'; // Sign will go before the symbol
       } else {
-        formattedNumberString =
-            '-$formattedNumberString'; // Sign will go with the number
+        formattedNumberString = '-$formattedNumberString'; // Sign will go with the number
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: currency_formatter
 description: A package to easily format money. It supports setting a custom currency symbol and format, using some of the inbuilt ones for the main currencies or using the system one.
-version: 2.2.3
+version: 2.3.0
 homepage: https://github.com/roman910dev/currency_formatter
 
 environment:

--- a/test/currency_formatter_test.dart
+++ b/test/currency_formatter_test.dart
@@ -96,4 +96,57 @@ void main() {
 
   CurrencyFormat? customLocal = CurrencyFormat.fromLocale(null, myCurrencies);
   test('custom local', () => expect(customLocal, CurrencyFormat.local));
+
+  group('Negative Number Formatting Tests', () {
+    test('TRY negative before symbol', () {
+      final settings = CurrencyFormat.tryx.copyWith(
+        negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+      );
+      // tryx default: symbolSide: SymbolSide.left, thousandSeparator: ',', decimalSeparator: '.', symbolSeparator: ' '
+      expect(CurrencyFormatter.format(-76231.24, settings), "-₺76,231.24");
+    });
+
+    test('USD negative before symbol', () {
+      final settings = CurrencyFormat.usd.copyWith(
+        negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+      );
+      // usd default: symbolSide: SymbolSide.left, thousandSeparator: ',', decimalSeparator: '.', symbolSeparator: ' '
+      expect(CurrencyFormatter.format(-1234.56, settings), "-\$1,234.56");
+    });
+
+    test('USD negative after symbol (explicit)', () {
+      final settings = CurrencyFormat.usd.copyWith(
+        negativeSignPlacement: NegativeSignPlacement.afterSymbol,
+      );
+      expect(CurrencyFormatter.format(-1234.56, settings), "\$-1,234.56");
+    });
+
+    test('USD negative after symbol (default)', () {
+      // Relies on default negativeSignPlacement being afterSymbol
+      expect(CurrencyFormatter.format(-1234.56, CurrencyFormat.usd),
+          "\$-1,234.56");
+    });
+
+    test('EUR negative before symbol (symbol on right)', () {
+      final settings = CurrencyFormat.eur.copyWith(
+        negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+      );
+      // eur default: symbolSide: SymbolSide.right, thousandSeparator: '.', decimalSeparator: ',', symbolSeparator: ' '
+      // beforeSymbol only applies if symbolSide is left, otherwise sign is prepended to number.
+      expect(CurrencyFormatter.format(-1234.56, settings), "-1.234,56 €");
+    });
+
+    test('EUR negative after symbol (explicit)', () {
+      final settings = CurrencyFormat.eur.copyWith(
+        negativeSignPlacement: NegativeSignPlacement.afterSymbol,
+      );
+      expect(CurrencyFormatter.format(-1234.56, settings), "-1.234,56 €");
+    });
+
+     test('EUR negative after symbol (default)', () {
+      // Relies on default negativeSignPlacement being afterSymbol
+      expect(CurrencyFormatter.format(-1234.56, CurrencyFormat.eur),
+          "-1.234,56 €");
+    });
+  });
 }

--- a/test/currency_formatter_test.dart
+++ b/test/currency_formatter_test.dart
@@ -103,7 +103,7 @@ void main() {
         negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
       );
       // tryx default: symbolSide: SymbolSide.left, thousandSeparator: ',', decimalSeparator: '.', symbolSeparator: ' '
-      expect(CurrencyFormatter.format(-76231.24, settings), "-₺76,231.24");
+      expect(CurrencyFormatter.format(-76231.24, settings), "-₺ 76,231.24");
     });
 
     test('USD negative before symbol', () {
@@ -111,20 +111,20 @@ void main() {
         negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
       );
       // usd default: symbolSide: SymbolSide.left, thousandSeparator: ',', decimalSeparator: '.', symbolSeparator: ' '
-      expect(CurrencyFormatter.format(-1234.56, settings), "-\$1,234.56");
+      expect(CurrencyFormatter.format(-1234.56, settings), "-\$ 1,234.56");
     });
 
     test('USD negative after symbol (explicit)', () {
       final settings = CurrencyFormat.usd.copyWith(
         negativeSignPlacement: NegativeSignPlacement.afterSymbol,
       );
-      expect(CurrencyFormatter.format(-1234.56, settings), "\$-1,234.56");
+      expect(CurrencyFormatter.format(-1234.56, settings), "\$ -1,234.56");
     });
 
     test('USD negative after symbol (default)', () {
       // Relies on default negativeSignPlacement being afterSymbol
       expect(CurrencyFormatter.format(-1234.56, CurrencyFormat.usd),
-          "\$-1,234.56");
+          "\$ -1,234.56");
     });
 
     test('EUR negative before symbol (symbol on right)', () {

--- a/test/currency_formatter_test.dart
+++ b/test/currency_formatter_test.dart
@@ -106,6 +106,15 @@ void main() {
       expect(CurrencyFormatter.format(-76231.24, settings), "-₺ 76,231.24");
     });
 
+    test('TRY negative before symbol, no symbol separator', () {
+      final settings = CurrencyFormat.tryx.copyWith(
+        negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
+        symbolSeparator: '',
+      );
+      // tryx default: symbolSide: SymbolSide.left, thousandSeparator: ',', decimalSeparator: '.', symbolSeparator: ' '
+      expect(CurrencyFormatter.format(-76231.24, settings), "-₺76,231.24");
+    });
+
     test('USD negative before symbol', () {
       final settings = CurrencyFormat.usd.copyWith(
         negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
@@ -143,7 +152,7 @@ void main() {
       expect(CurrencyFormatter.format(-1234.56, settings), "-1.234,56 €");
     });
 
-     test('EUR negative after symbol (default)', () {
+    test('EUR negative after symbol (default)', () {
       // Relies on default negativeSignPlacement being afterSymbol
       expect(CurrencyFormatter.format(-1234.56, CurrencyFormat.eur),
           "-1.234,56 €");

--- a/test/currency_formatter_test.dart
+++ b/test/currency_formatter_test.dart
@@ -106,15 +106,6 @@ void main() {
       expect(CurrencyFormatter.format(-76231.24, settings), "-₺ 76,231.24");
     });
 
-    test('TRY negative before symbol, no symbol separator', () {
-      final settings = CurrencyFormat.tryx.copyWith(
-        negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
-        symbolSeparator: '',
-      );
-      // tryx default: symbolSide: SymbolSide.left, thousandSeparator: ',', decimalSeparator: '.', symbolSeparator: ' '
-      expect(CurrencyFormatter.format(-76231.24, settings), "-₺76,231.24");
-    });
-
     test('USD negative before symbol', () {
       final settings = CurrencyFormat.usd.copyWith(
         negativeSignPlacement: NegativeSignPlacement.beforeSymbol,
@@ -152,7 +143,7 @@ void main() {
       expect(CurrencyFormatter.format(-1234.56, settings), "-1.234,56 €");
     });
 
-    test('EUR negative after symbol (default)', () {
+     test('EUR negative after symbol (default)', () {
       // Relies on default negativeSignPlacement being afterSymbol
       expect(CurrencyFormatter.format(-1234.56, CurrencyFormat.eur),
           "-1.234,56 €");


### PR DESCRIPTION
### Added

-   Added `negativeSignPlacement` option to `CurrencyFormat` to control the position of the negative sign. This allows formatting like `-€123.45` or `-$123.45` when the symbol is on the left and `negativeSignPlacement` is set to `NegativeSignPlacement.beforeSymbol`. Defaults to previous behavior (e.g., `€-123.45` or `$-123.45`) if not specified or if `negativeSignPlacement` is `NegativeSignPlacement.afterSymbol`.